### PR TITLE
Fix Detekt warnings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,25 +45,25 @@ allprojects {
                     baseline = moduleDetektBaseline
                 }
                 basePath = projectDir.path
-                reports {
-                    xml {
-                        enabled = true
-                    }
-                    html {
-                        enabled = false
-                    }
-                    txt {
-                        enabled = false
-                    }
-                    // FYI: Sarif upload to GitHub requires GitHub Enterprise tear.
-                    sarif {
-                        enabled = false
-                    }
-                }
             }
 
             tasks.withType<io.gitlab.arturbosch.detekt.Detekt>().configureEach {
                 jvmTarget = jvmTargetVersion
+                reports {
+                    xml {
+                        required.set(true)
+                    }
+                    html {
+                        required.set(true)
+                    }
+                    txt {
+                        required.set(false)
+                    }
+                    // FYI: Sarif upload to GitHub requires GitHub Enterprise tear.
+                    sarif {
+                        required.set(false)
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
`DetectExtension::reports` fun is deprecated, it's better to customise it in the task. `DetectReport.enabled` field is also deprecated in favour of `DetectReport.required` property.

Also I set HTML report to `true` because it's far more human-readable than XML. Set it to `false` if you disagree :)